### PR TITLE
Ensure CSS is emitted in SSR build

### DIFF
--- a/src/sdk/contexts/get-context.ts
+++ b/src/sdk/contexts/get-context.ts
@@ -4,7 +4,7 @@ import { type Context } from '../../core';
 export const getContext = (
   supabase: SupabaseClient
 ) => (
-  projectId: string
+  contextId: string
 ) => supabase
   .from('contexts')
   .select(`
@@ -12,7 +12,7 @@ export const getContext = (
     name,
     project_id
   `)
-  .eq('id', projectId)
+  .eq('id', contextId)
   .single()
   .then(({ error, data }) =>{ 
   if (error || !data) return { error, data: undefined };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [dts()],
   build: {
     ssr: true,
-    ssrEmitAssets: true,
+    emitAssets: true,
     target: 'node16',
     cssCodeSplit: false,
     lib: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [dts()],
   build: {
     ssr: true,
+    ssrEmitAssets: true,
     target: 'node16',
     cssCodeSplit: false,
     lib: {


### PR DESCRIPTION
### In this PR

- I was running into issues with the CSS not being emitted when I tried to build and use the SDK locally in plugin development, but adding `ssrEmitAssets: true` to the vite build config seemed to fix it. I then found that this will [eventually be replaced](https://vite.dev/config/build-options#build-ssremitassets) by just `emitAssets`, which already works, so I used that name.
- Unrelated, but I noticed the variable passing the context id to the Supabase API was `projectId` when it should be `contextId`