### PR TITLE
Add @font-face declarations to SDK

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -11,6 +11,98 @@
 @import './switch/index.css';
 @import './tooltip/index.css';
 
+@font-face {
+  font-family: Inter;
+  src: url('/fonts/inter/Inter.ttf');
+}
+
+@font-face {
+  font-family: Poppins;
+  src: url('/fonts/poppins/Poppins-Regular.ttf');
+}
+
+@font-face {
+  font-family: Poppins;
+  src: url('/fonts/poppins/Poppins-Italic.ttf');
+  font-style: italic;
+}
+
+@font-face {
+  font-family: Poppins;
+  src: url('/fonts/poppins/Poppins-Light.ttf');
+  font-weight: 300;
+}
+
+@font-face {
+  font-family: Poppins;
+  src: url('/fonts/poppins/Poppins-LightItalic.ttf');
+  font-style: italic;
+  font-weight: 300;
+}
+
+@font-face {
+  font-family: Poppins;
+  src: url('/fonts/poppins/Poppins-Regular.ttf');
+  font-weight: 400;
+}
+
+@font-face {
+  font-family: Poppins;
+  src: url('/fonts/poppins/Poppins-Italic.ttf');
+  font-style: italic;
+  font-weight: 400;
+}
+
+@font-face {
+  font-family: Poppins;
+  src: url('/fonts/poppins/Poppins-Medium.ttf');
+  font-weight: 500;
+}
+
+@font-face {
+  font-family: Poppins;
+  src: url('/fonts/poppins/Poppins-MediumItalic.ttf');
+  font-style: italic;
+  font-weight: 500;
+}
+
+@font-face {
+  font-family: Poppins;
+  src: url('/fonts/poppins/Poppins-SemiBold.ttf');
+  font-weight: 600;
+}
+
+@font-face {
+  font-family: Poppins;
+  src: url('/fonts/poppins/Poppins-SemiBoldItalic.ttf');
+  font-style: italic;
+  font-weight: 600;
+}
+
+@font-face {
+  font-family: Poppins;
+  src: url('/fonts/poppins/Poppins-Bold.ttf');
+  font-weight: 700;
+}
+
+@font-face {
+  font-family: Poppins;
+  src: url('/fonts/poppins/Poppins-BoldItalic.ttf');
+  font-style: italic;
+  font-weight: 700;
+}
+
+@font-face {
+  font-family: Lora;
+  src: url('/fonts/lora/Lora.ttf');
+}
+
+@font-face {
+  font-family: Lora;
+  src: url('/fonts/lora/Lora-Italic.ttf');
+  font-style: italic;
+}
+
 :root {
   /** Colors **/
   --dark-blue: #07498a;


### PR DESCRIPTION
### In this PR

Add some `@font-face` declarations from `recogito-client`, so that the root Recogito fonts are applied correctly in a plugin that renders in a separate DOM tree from the client application.

### Notes 

Not sure if this is the best way to handle this, or if the plugin itself should contain these declarations? My assumption is that anywhere the SDK is running, these fonts will be available from the client app, but maybe not.