### PR TITLE
Add Autosuggest component from recogito-client

### DIFF
--- a/src/components/Autosuggest/Autosuggest.css
+++ b/src/components/Autosuggest/Autosuggest.css
@@ -1,0 +1,67 @@
+.autosuggest {
+  display: inline;
+  position: relative;
+  z-index: 1;
+}
+
+.autosuggest input {
+  background-color: transparent;
+  border: none;
+  border-radius: 3px;
+  font-size: 12px;
+  padding: 4px;
+  outline: none;
+}
+
+.autosuggest input:focus {
+  box-shadow: none;
+}
+
+.autosuggest ul {
+  background-color: #fff;
+  border-radius: 3px;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.25);
+  list-style-type: none;
+  margin: 0;
+  max-height: 200px;
+  min-width: 100px;
+  overflow-y: auto;
+  padding: 0;
+  position: absolute;
+  z-index: 9999;
+}
+
+.autosuggest ul:empty {
+  display: none;
+}
+
+.autosuggest li {
+  align-items: center;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: flex;
+  font-size: 12px;
+  justify-content: space-between;
+  padding: 3px 8px;
+  width: 100%;
+}
+
+.autosuggest li .term-color {
+  border-radius: 50%;
+  display: block;
+  height: 7px;
+  margin-right: 0.25rem;
+  width: 7px;
+}
+
+.autosuggest li.selected {
+  background-color: var(--button-focus-outline-color);
+}
+
+.autosuggest li:first-child {
+  border-radius: 3px 3px 0 0;
+}
+
+.autosuggest li:last-child {
+  border-radius: 0 0 3px 3px;
+}

--- a/src/components/Autosuggest/Autosuggest.tsx
+++ b/src/components/Autosuggest/Autosuggest.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useRef, useState } from 'react';
+import * as Popover from '@radix-ui/react-popover';
+import { AutosizeInput } from '../AutosizeInput';
+import type { VocabularyTerm } from '../../core';
+
+import './Autosuggest.css';
+
+const getVocabSuggestions = (query: string, vocabulary?: VocabularyTerm[]) =>
+  (vocabulary || []).filter((term) =>
+    term.label.toLowerCase().startsWith(query.toLowerCase()),
+  );
+
+interface AutosuggestProps {
+  autoFocus?: boolean;
+
+  autoSize?: boolean;
+
+  openOnFocus?: boolean;
+
+  placeholder?: string;
+
+  value?: VocabularyTerm;
+
+  vocabulary?: VocabularyTerm[];
+
+  onChange(value: VocabularyTerm): void;
+
+  onSubmit(value: VocabularyTerm): void;
+
+  onCancel?(): void;
+}
+
+export const Autosuggest = (props: AutosuggestProps) => {
+  const element = useRef<HTMLDivElement>(null);
+
+  const [suggestions, setSuggestions] = useState<VocabularyTerm[]>(
+    props.openOnFocus ? props.vocabulary || [] : [],
+  );
+
+  const [highlightedIndex, setHighlightedIndex] = useState<
+    number | undefined
+  >();
+
+  useEffect(() => {
+    element.current
+      ?.querySelector('.selected')
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex]);
+
+  const getSuggestions = (value: string) => {
+    const suggestions = getVocabSuggestions(value, props.vocabulary);
+    setSuggestions(suggestions);
+  };
+
+  const onSubmit = () => {
+    if (highlightedIndex !== undefined) {
+      // Submit highligted suggestion
+      props.onSubmit(suggestions[highlightedIndex]);
+    } else {
+      // Submit input value
+      const trimmed = props.value?.label.trim();
+
+      if (trimmed) {
+        // If there is a vocabulary term with the same label, use that
+        const matchingTerm = Array.isArray(props.vocabulary)
+          ? props.vocabulary.find(
+              (term) => term.label.toLowerCase() === trimmed.toLowerCase(),
+            )
+          : null;
+
+        if (matchingTerm) {
+          props.onSubmit(matchingTerm);
+        } else {
+          // Otherwise, just use as a freetext tag
+          props.onSubmit({ label: trimmed });
+        }
+      }
+    }
+
+    setSuggestions([]);
+    setHighlightedIndex(undefined);
+  };
+
+  const onKeyDown = (evt: React.KeyboardEvent) => {
+    if (evt.key === 'Enter') {
+      onSubmit();
+    } else if (evt.key === 'Escape') {
+      setSuggestions([]);
+      setHighlightedIndex(undefined);
+      props.onCancel?.();
+    } else {
+      // Neither enter nor cancel
+      if (suggestions.length > 0) {
+        if (evt.key === 'ArrowUp') {
+          if (highlightedIndex === undefined) {
+            setHighlightedIndex(0);
+          } else {
+            const prev = Math.max(0, highlightedIndex - 1);
+            setHighlightedIndex(prev);
+          }
+        } else if (evt.key === 'ArrowDown') {
+          if (highlightedIndex === undefined) {
+            setHighlightedIndex(0);
+          } else {
+            const next = Math.min(suggestions.length - 1, highlightedIndex + 1);
+            setHighlightedIndex(next);
+          }
+        }
+      } else {
+        // No suggestions: key down shows all vocab
+        // options (only for hard-wired vocabs!)
+        if (evt.key === 'ArrowDown') {
+          setSuggestions(props.vocabulary || []);
+        }
+      }
+    }
+  };
+
+  const onChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = evt.target;
+    props.onChange({ label: value });
+
+    // Typing on the input resets the highlight
+    setHighlightedIndex(undefined);
+
+    if (value) getSuggestions(value);
+    else setSuggestions([]);
+  };
+
+  return (
+    <Popover.Root open={suggestions.length > 0}>
+      <div ref={element} className="autosuggest">
+        <Popover.Anchor>
+          {props.autoSize ? (
+            <AutosizeInput
+              autoFocus={props.autoFocus}
+              value={props.value?.label || ''}
+              placeholder={props.placeholder}
+              onChange={onChange}
+              onKeyDown={onKeyDown}
+            />
+          ) : (
+            <input
+              autoFocus={props.autoFocus}
+              value={props.value?.label || ''}
+              placeholder={props.placeholder}
+              onChange={onChange}
+              onKeyDown={onKeyDown}
+            />
+          )}
+        </Popover.Anchor>
+
+        <Popover.Portal>
+          <Popover.Content
+            className="autosuggest"
+            onOpenAutoFocus={(evt) => evt.preventDefault()}
+            sideOffset={8}
+            align="start"
+          >
+            <ul>
+              {suggestions.map((term, index) => (
+                <li
+                  key={`${term.label}-${index}`}
+                  onClick={onSubmit}
+                  onMouseEnter={() => setHighlightedIndex(index)}
+                  className={
+                    highlightedIndex === index ? 'selected' : undefined
+                  }
+                >
+                  <span>{term.label}</span>
+
+                  {term.color && (
+                    <span
+                      className="term-color"
+                      style={{
+                        backgroundColor: term.color,
+                      }}
+                    />
+                  )}
+                </li>
+              ))}
+            </ul>
+          </Popover.Content>
+        </Popover.Portal>
+      </div>
+    </Popover.Root>
+  );
+};

--- a/src/components/Autosuggest/index.ts
+++ b/src/components/Autosuggest/index.ts
@@ -1,0 +1,1 @@
+export * from './Autosuggest';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './AutosizeInput';
+export * from './Autosuggest';
 export * from './Avatar';
 export * from './Button';
 export * from './Presence';


### PR DESCRIPTION
### In this PR

- Pull the `Autosuggest` component [verbatim from recogito-client](https://github.com/recogito/recogito-client/blob/develop/src/components/Autosuggest/Autosuggest.tsx), for use in the bochum plugin

### Questions

I've just noticed that there seem to be two patterns for CSS here—components listed under `src/styles/<component>/index.css` and then some like `src/components/<Component>/<Component>.css`. Is one or the other preferred? Ok to mix?