### PR TITLE
Add tags, tag/contributor utils, and FilterState

### DIFF
--- a/src/components/FilterState/FilterState.tsx
+++ b/src/components/FilterState/FilterState.tsx
@@ -14,10 +14,6 @@ export interface FilterSetting<T> {
 }
 
 interface FilterStateContextValue {
-  hideAll: boolean;
-
-  setHideAll(hideAll: boolean): void;
-
   layerSettings?: FilterSetting<string[] | undefined>;
 
   setLayerSettings: React.Dispatch<
@@ -55,8 +51,6 @@ interface FilterStateProps {
 }
 
 export const FilterState = (props: FilterStateProps) => {
-  const [hideAll, setHideAll] = useState(false);
-
   const [layerSettings, setLayerSettings] = useState<
     FilterSetting<string[] | undefined> | undefined
   >();
@@ -77,11 +71,6 @@ export const FilterState = (props: FilterStateProps) => {
 
   // Note: this may move into the context provider later
   useEffect(() => {
-    if (hideAll) {
-      setChained(() => () => false);
-      return;
-    }
-
     const filters = [
       layerSettings?.filter,
       contributorSettings?.filter,
@@ -95,7 +84,7 @@ export const FilterState = (props: FilterStateProps) => {
     } else {
       setChained(undefined);
     }
-  }, [hideAll, layerSettings, contributorSettings, tagSettings, visibilitySettings]);
+  }, [layerSettings, contributorSettings, tagSettings, visibilitySettings]);
 
   return (
     <FilterStateContext.Provider
@@ -108,8 +97,6 @@ export const FilterState = (props: FilterStateProps) => {
         setTagSettings,
         visibilitySettings,
         setVisibilitySettings,
-        hideAll,
-        setHideAll,
         filter: chained,
       }}
     >
@@ -126,7 +113,6 @@ export const useFilter = () => {
     contributorSettings,
     tagSettings,
     visibilitySettings,
-    hideAll,
     filter,
   } = useContext(FilterStateContext);
 
@@ -136,7 +122,6 @@ export const useFilter = () => {
     contributorSettings,
     tagSettings,
     visibilitySettings,
-    hideAll,
   ].filter(Boolean).length;
 
   return { filter, numConditions };

--- a/src/components/FilterState/FilterState.tsx
+++ b/src/components/FilterState/FilterState.tsx
@@ -1,0 +1,143 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { Annotation, Filter, User } from '@annotorious/react';
+
+export interface FilterSetting<T> {
+  state: T;
+
+  filter: (a: Annotation) => boolean;
+}
+
+interface FilterStateContextValue {
+  hideAll: boolean;
+
+  setHideAll(hideAll: boolean): void;
+
+  layerSettings?: FilterSetting<string[] | undefined>;
+
+  setLayerSettings: React.Dispatch<
+    React.SetStateAction<FilterSetting<string[] | undefined> | undefined>
+  >;
+
+  contributorSettings?: FilterSetting<User[]>;
+
+  setContributorSettings: React.Dispatch<
+    React.SetStateAction<FilterSetting<User[]> | undefined>
+  >;
+
+  tagSettings?: FilterSetting<string[]>;
+
+  setTagSettings: React.Dispatch<
+    React.SetStateAction<FilterSetting<string[]> | undefined>
+  >;
+
+  visibilitySettings?: FilterSetting<'public' | 'private' | 'all'>;
+
+  setVisibilitySettings: React.Dispatch<
+    React.SetStateAction<
+      FilterSetting<'all' | 'private' | 'public'> | undefined
+    >
+  >;
+
+  filter?: Filter;
+}
+
+// @ts-ignore
+const FilterStateContext = createContext<FilterStateContextValue>();
+
+interface FilterStateProps {
+  children: ReactNode;
+}
+
+export const FilterState = (props: FilterStateProps) => {
+  const [hideAll, setHideAll] = useState(false);
+
+  const [layerSettings, setLayerSettings] = useState<
+    FilterSetting<string[] | undefined> | undefined
+  >();
+
+  const [contributorSettings, setContributorSettings] = useState<
+    FilterSetting<User[]> | undefined
+  >();
+
+  const [tagSettings, setTagSettings] = useState<
+    FilterSetting<string[]> | undefined
+  >();
+
+  const [visibilitySettings, setVisibilitySettings] = useState<
+    FilterSetting<'all' | 'private' | 'public'> | undefined
+  >();
+
+  const [chained, setChained] = useState<Filter | undefined>();
+
+  // Note: this may move into the context provider later
+  useEffect(() => {
+    if (hideAll) {
+      setChained(() => () => false);
+      return;
+    }
+
+    const filters = [
+      layerSettings?.filter,
+      contributorSettings?.filter,
+      tagSettings?.filter,
+      visibilitySettings?.filter,
+    ].filter((fn): fn is (a: Annotation) => boolean => Boolean(fn));
+
+    if (filters.length > 0) {
+      const chained = (a: Annotation) => filters.every((fn) => fn(a));
+      setChained(() => chained);
+    } else {
+      setChained(undefined);
+    }
+  }, [hideAll, layerSettings, contributorSettings, tagSettings, visibilitySettings]);
+
+  return (
+    <FilterStateContext.Provider
+      value={{
+        layerSettings,
+        setLayerSettings,
+        contributorSettings,
+        setContributorSettings,
+        tagSettings,
+        setTagSettings,
+        visibilitySettings,
+        setVisibilitySettings,
+        hideAll,
+        setHideAll,
+        filter: chained,
+      }}
+    >
+      {props.children}
+    </FilterStateContext.Provider>
+  );
+};
+
+export const useFilterSettingsState = () => useContext(FilterStateContext);
+
+export const useFilter = () => {
+  const {
+    layerSettings,
+    contributorSettings,
+    tagSettings,
+    visibilitySettings,
+    hideAll,
+    filter,
+  } = useContext(FilterStateContext);
+
+  // Number of filter conditions chained in the filter
+  const numConditions = [
+    layerSettings,
+    contributorSettings,
+    tagSettings,
+    visibilitySettings,
+    hideAll,
+  ].filter(Boolean).length;
+
+  return { filter, numConditions };
+};

--- a/src/components/FilterState/index.ts
+++ b/src/components/FilterState/index.ts
@@ -1,0 +1,1 @@
+export * from './FilterState';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,7 @@ export * from './AutosizeInput';
 export * from './Autosuggest';
 export * from './Avatar';
 export * from './Button';
+export * from './FilterState';
 export * from './Presence';
 export * from './Spinner';
 export * from './Timestamp';

--- a/src/core/utils/contributors.ts
+++ b/src/core/utils/contributors.ts
@@ -1,0 +1,48 @@
+import type { PresentUser, User } from '@annotorious/react';
+import type { SupabaseAnnotation } from '../SupbaseAnnotation';
+
+/** Determines the creator of the annotation by the target, or the first body **/
+export const getContributors = (annotation: SupabaseAnnotation): User[] => {
+  const contributors: User[] = [
+    annotation.target.creator!,
+    ...annotation.bodies.map((b) => b.creator!),
+  ].filter(Boolean); // Remove undefined
+
+  // De-duplicate
+  return contributors.reduce<User[]>(
+    (unique, user) =>
+      unique.some((u) => u.id === user.id) ? unique : [...unique, user],
+    []
+  );
+};
+
+/** Determines the list of unique contributors in the given annotation list */
+export const enumerateContributors = (
+  present: PresentUser[],
+  annotations: SupabaseAnnotation[],
+  visibleLayers?: string[]
+): User[] => {
+  const layerIds = visibleLayers ? new Set(visibleLayers) : undefined;
+
+  const users = annotations.reduce<User[]>((enumerated, a) => {
+    // If there is a layer filter, ignore annotations outside of visible layers
+    if (layerIds && a.layer_id && !layerIds.has(a.layer_id)) return enumerated;
+
+    const contributors: User[] = [
+      a.target.creator!,
+      ...a.bodies.map((b) => b.creator!),
+    ].filter(Boolean); // Remove undefined
+
+    return [...enumerated, ...contributors].reduce<User[]>(
+      (unique, user) => ( // De-duplicate
+        unique.some((u) => u.id === user.id) ? unique : [...unique, user]
+      ),
+      []
+    );
+  }, []);
+
+  return users.map((u) => {
+    const presentUser = present.find((p) => p.id === u.id);
+    return presentUser ? presentUser : u;
+  });
+};

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './contributors';
 export * from './matchesExtensionPoint';
 export * from './tags';

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './matchesExtensionPoint';
+export * from './tags';

--- a/src/core/utils/tags.ts
+++ b/src/core/utils/tags.ts
@@ -1,0 +1,53 @@
+import type { Annotation, AnnotationBody } from '@annotorious/react';
+import type { SupabaseAnnotation } from '../SupbaseAnnotation';
+import type { VocabularyTerm } from '../VocabularyTerm';
+
+export const parseTagBody = (
+  body: AnnotationBody
+): VocabularyTerm | undefined => {
+  if (!body.value) return undefined;
+
+  // For backwards-compatibility: support object and string tags
+  if (body.value.startsWith('{')) {
+    try {
+      return JSON.parse(body.value) as VocabularyTerm;
+    } catch {
+      return { label: body.value };
+    }
+  }
+
+  return { label: body.value };
+};
+
+export const getTags = (annotation: Annotation): VocabularyTerm[] =>
+  (annotation.bodies || [])
+    .filter((b) => b.purpose === 'tagging')
+    .map(parseTagBody)
+    .filter((t): t is VocabularyTerm => Boolean(t));
+
+/** Determines the list of unique tags in the given annotation list **/
+export const enumerateTags = (
+  annotations: SupabaseAnnotation[],
+  visibleLayers?: string[]
+): VocabularyTerm[] => {
+  const layerIds = visibleLayers ? new Set(visibleLayers) : undefined;
+
+  return annotations
+    .reduce<AnnotationBody[]>((enumerated, annotation) => {
+      // If there is a layer filter, ignore annotations outside of visible layers
+      if (layerIds && annotation.layer_id && !layerIds.has(annotation.layer_id))
+        return enumerated;
+
+      const tags = annotation.bodies.filter((b) => b.purpose === 'tagging');
+      return [...enumerated, ...tags];
+    }, [])
+    .sort((a, b) => (a.created! > b.created! ? 1 : -1))
+    .reduce<VocabularyTerm[]>((firstOccurrences, body) => {
+      const tag = parseTagBody(body);
+      if (!tag) return firstOccurrences;
+
+      const key = tag.id || tag.label;
+      const exists = firstOccurrences.some((t) => (t.id || t.label) === key);
+      return exists ? firstOccurrences : [...firstOccurrences, tag];
+    }, []);
+};

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -6,13 +6,14 @@ import { getContext, isOpenJoinEditFromContext } from './contexts';
 import { getDocument } from './documents';
 import { getMyProfile } from './profile';
 import { getProject, hasSelectPermissions } from './project';
-import { 
-  getDocumentLayersInContext, 
-  getDocumentLayersInProject, 
-  getLayerPolicies, 
-  getLayersInContext, 
-  getLayersInProject 
+import {
+  getDocumentLayersInContext,
+  getDocumentLayersInProject,
+  getLayerPolicies,
+  getLayersInContext,
+  getLayersInProject
 } from './layers';
+import { getProjectTagVocabulary } from './tags';
 
 const createSDK = (supabase: SupabaseClient) => ({
   annotations: {
@@ -43,6 +44,10 @@ const createSDK = (supabase: SupabaseClient) => ({
   project: {
     get: getProject(supabase),
     hasSelectPermissions: hasSelectPermissions(supabase)
+  },
+
+  tags: {
+    getProjectTagVocabulary: getProjectTagVocabulary(supabase)
   },
 
   supabase,

--- a/src/sdk/tags/get-tags.ts
+++ b/src/sdk/tags/get-tags.ts
@@ -1,0 +1,35 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { VocabularyTerm } from '../../core';
+
+export const getProjectTagVocabulary =
+  (supabase: SupabaseClient) => (projectId: string) =>
+    supabase
+      .from('tag_definitions')
+      .select(
+        `
+        id,
+        name,
+        target_type,
+        scope,
+        scope_id,
+        metadata
+      `
+      )
+      .match({ scope: 'project', scope_id: projectId })
+      .then(({ error, data }) => {
+        if (error || !data) {
+          return { error, data: [] as VocabularyTerm[] };
+        }
+
+        return {
+          error,
+          data: data.map(
+            (def) =>
+              ({
+                label: def.name,
+                color: def.metadata?.color,
+                id: def.metadata?.id,
+              } as VocabularyTerm)
+          ),
+        };
+      });

--- a/src/sdk/tags/index.ts
+++ b/src/sdk/tags/index.ts
@@ -1,0 +1,1 @@
+export * from './get-tags';


### PR DESCRIPTION
### In this PR

For the Bochum plugin:
- Add tag retrieval, and utilities for tags and contributors, to the SDK
- Add `FilterState` from the client to the SDK
- Add `hideAll` filtering option, which hides all annotations on a document, per wireframes

### Notes

A lot of this is directly copied from the client app (tag and contrib utils, `FilterState`) so we should import there instead of duplicating. Once the first version of the plugin is done, and we mint a new SDK version, I'll do a big pass over the client app to de-duplicate and DRY up all of these.